### PR TITLE
Fixed email in "Please check inbox at ..."

### DIFF
--- a/ucdeconvolve/_api/_api.py
+++ b/ucdeconvolve/_api/_api.py
@@ -112,7 +112,7 @@ def register(
         return apiutils.process_response(response)
     else:
         # Tell user to go check email
-        print(f"Please check inbox at dmcharytonowicz@gmail.com and copy/paste activation code into prompt below.")
+        print(f"Please check inbox at {params['email']} and copy/paste activation code into prompt below.")
         
         # If we are dynamic, we can wait for user prompt to get the activation code
         activation_code = getpass("Activation Code: ")


### PR DESCRIPTION
Registration email was fixed to `dmcharytonowicz@gmail.com` in:
```
print(f"Please check inbox at dmcharytonowicz@gmail.com and copy/paste activation code into prompt below.")
```
Corrected to show user's email entered during registration:
```
print(f"Please check inbox at {params['email']} and copy/paste activation code into prompt below.")
```