### PR TITLE
Update getting_started.ipynb

### DIFF
--- a/docs/notebooks/getting_started.ipynb
+++ b/docs/notebooks/getting_started.ipynb
@@ -158,7 +158,7 @@
    "source": [
     "### New Session Authentication\n",
     "\n",
-    "When you start a new python instance, you can authenticate your API by simply calling the ``ucd.tl.authenticate([token])`` function\n",
+    "When you start a new python instance, you can authenticate your API by simply calling the ``ucd.api.authenticate([token])`` function\n",
     "and passing your user access token. It will be appended to your settings module at ``ucd.settings.token``"
    ]
   },


### PR DESCRIPTION
the authenticate() is under ucd.api and not ucd.tl .